### PR TITLE
refactor: 상속구조를 조합으로 변경하기(Cell)

### DIFF
--- a/src/main/java/cleancode/minesweeper/tobe/GameBoard.java
+++ b/src/main/java/cleancode/minesweeper/tobe/GameBoard.java
@@ -1,9 +1,6 @@
 package cleancode.minesweeper.tobe;
 
-import cleancode.minesweeper.tobe.cell.Cell;
-import cleancode.minesweeper.tobe.cell.EmptyCell;
-import cleancode.minesweeper.tobe.cell.LandMineCell;
-import cleancode.minesweeper.tobe.cell.NumberCell;
+import cleancode.minesweeper.tobe.cell.*;
 import cleancode.minesweeper.tobe.gamelevel.GameLevel;
 
 import java.util.Arrays;

--- a/src/main/java/cleancode/minesweeper/tobe/cell/Cell.java
+++ b/src/main/java/cleancode/minesweeper/tobe/cell/Cell.java
@@ -1,31 +1,21 @@
 package cleancode.minesweeper.tobe.cell;
 
-public abstract class Cell {
+public interface Cell {
 
-    protected static final String FLAG_SIGN = "⚑";
-    protected static final String UNCHECKED_SIGN = "□";
-    protected boolean isFlagged;
-    protected boolean isOpened;
+    String FLAG_SIGN = "⚑";
+    String UNCHECKED_SIGN = "□";
 
-    public abstract boolean isLandMine();
+    boolean isLandMine();
 
-    public abstract boolean hasLandMineCount();
+    boolean hasLandMineCount();
 
-    public abstract String getSign();
+    String getSign();
 
-    public void flag() {
-        this.isFlagged = true;
-    }
+    void flag();
 
-    public void open() {
-        this.isOpened = true;
-    }
+    void open();
 
-    public boolean isChecked() {
-        return isFlagged || isOpened;
-    }
+    boolean isChecked();
 
-    public boolean isOpened() {
-        return this.isOpened;
-    }
+    boolean isOpened();
 }

--- a/src/main/java/cleancode/minesweeper/tobe/cell/CellState.java
+++ b/src/main/java/cleancode/minesweeper/tobe/cell/CellState.java
@@ -1,0 +1,35 @@
+package cleancode.minesweeper.tobe.cell;
+
+public class CellState {
+    private boolean isFlagged;
+    private boolean isOpened;
+
+    public CellState(boolean isFlagged, boolean isOpened) {
+        this.isFlagged = isFlagged;
+        this.isOpened = isOpened;
+    }
+
+    public static CellState initialize(){
+        return new CellState(false, false);
+    }
+
+    public void flag() {
+        this.isFlagged = true;
+    }
+
+    public void open() {
+        this.isOpened = true;
+    }
+
+    public boolean isChecked() {
+        return isFlagged || isOpened;
+    }
+
+    public boolean isOpened() {
+        return this.isOpened;
+    }
+
+    public boolean isFlagged() {
+        return this.isFlagged;
+    }
+}

--- a/src/main/java/cleancode/minesweeper/tobe/cell/EmptyCell.java
+++ b/src/main/java/cleancode/minesweeper/tobe/cell/EmptyCell.java
@@ -1,7 +1,9 @@
 package cleancode.minesweeper.tobe.cell;
 
-public class EmptyCell extends Cell {
+public class EmptyCell implements Cell {
     private static final String EMPTY_SIGN = "■";
+
+    private final CellState cellState = CellState.initialize();
 
     @Override
     public boolean isLandMine() {
@@ -15,12 +17,32 @@ public class EmptyCell extends Cell {
 
     @Override
     public String getSign() {
-        if (isOpened) {
+        if (cellState.isOpened()) {
             return EMPTY_SIGN;
         }
-        if (isFlagged) {
+        if (cellState.isFlagged()) {
             return FLAG_SIGN;
         }
         return UNCHECKED_SIGN;
+    }
+
+    @Override
+    public void flag() {
+        cellState.flag();
+    }
+
+    @Override
+    public void open() {
+        cellState.open();
+    }
+
+    @Override
+    public boolean isChecked() {
+        return cellState.isChecked();
+    }
+
+    @Override
+    public boolean isOpened() {
+        return cellState.isOpened();
     }
 }

--- a/src/main/java/cleancode/minesweeper/tobe/cell/LandMineCell.java
+++ b/src/main/java/cleancode/minesweeper/tobe/cell/LandMineCell.java
@@ -1,9 +1,11 @@
 package cleancode.minesweeper.tobe.cell;
 
 
-public class LandMineCell extends Cell {
+public class LandMineCell implements Cell {
 
     private static final String LAND_MINE_SIGN = "☼";
+    private final CellState cellState = CellState.initialize();
+
 
     @Override
     public boolean isLandMine() {
@@ -17,12 +19,32 @@ public class LandMineCell extends Cell {
 
     @Override
     public String getSign() {
-        if (isOpened) {
+        if (cellState.isOpened()) {
             return LAND_MINE_SIGN;
         }
-        if (isFlagged) {
+        if (cellState.isFlagged()) {
             return FLAG_SIGN;
         }
         return UNCHECKED_SIGN;
+    }
+
+    @Override
+    public void flag() {
+        cellState.flag();
+    }
+
+    @Override
+    public void open() {
+        cellState.open();
+    }
+
+    @Override
+    public boolean isChecked() {
+        return cellState.isChecked();
+    }
+
+    @Override
+    public boolean isOpened() {
+        return cellState.isOpened();
     }
 }

--- a/src/main/java/cleancode/minesweeper/tobe/cell/NumberCell.java
+++ b/src/main/java/cleancode/minesweeper/tobe/cell/NumberCell.java
@@ -1,8 +1,11 @@
 package cleancode.minesweeper.tobe.cell;
 
-public class NumberCell extends Cell {
+public class NumberCell implements Cell {
 
     private final int nearbyLandMineCount;
+
+    private final CellState cellState = CellState.initialize();
+
 
     public NumberCell(int nearbyLandMineCount) {
         this.nearbyLandMineCount = nearbyLandMineCount;
@@ -20,12 +23,32 @@ public class NumberCell extends Cell {
 
     @Override
     public String getSign() {
-        if (isOpened) {
+        if (cellState.isOpened()) {
             return String.valueOf(nearbyLandMineCount);
         }
-        if (isFlagged) {
+        if (cellState.isFlagged()) {
             return FLAG_SIGN;
         }
         return UNCHECKED_SIGN;
+    }
+
+    @Override
+    public void flag() {
+        cellState.flag();
+    }
+
+    @Override
+    public void open() {
+        cellState.open();
+    }
+
+    @Override
+    public boolean isChecked() {
+        return cellState.isChecked();
+    }
+
+    @Override
+    public boolean isOpened() {
+        return cellState.isOpened();
     }
 }


### PR DESCRIPTION
### 상속과 조합
상속은 부모, 자식의 결합도가 높아 수정이 어렵다
→ 상속보다 **조합과 인터페이스**를 활용하자

Cell을 상속구조 → 인터페이스로 변경
CellState 생성
